### PR TITLE
Fix dependencies, simplify

### DIFF
--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -16,18 +16,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           BiocManager::install(c("bugsigdbr", "readr", "BiocFileCache", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports"))
         shell: Rscript {0}
-
-      - name: Setup git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
 
       - name: Export bugphyzz
         run: |
@@ -37,7 +30,8 @@ jobs:
 
       - name: Commit Exports
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
           git add . 
           git commit -m "Weekly export update"
           git push origin main

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -19,7 +19,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          BiocManager::install(c("bugsigdbr", "readr", "BiocFileCache", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports"))
+         pkgs <- c("bugsigdbr", "logr", "BiocFileCache", "tidy", "BiocParallel",
+                   "sdgamboa/taxPPro", "waldronlab/bugphyzz",
+                   "waldronlab/bugphyzzExports",)
+         BiocManager::install(pkgs, dependencies = TRUE)
         shell: Rscript {0}
 
       - name: Export bugphyzz

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -10,42 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     container: bioconductor/bioconductor_docker:devel
     env:
-      GITHUB_PAT: ${{ secrets.wl_pat }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
-      - name: Checkout bugphyzzExports 
+      - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          path: bugphyzzExports
-
-      - name: Checkout bugphyzz
-        uses: actions/checkout@v3
-        with:
-          repository: waldronlab/bugphyzz
-          path: bugphyzz
 
       - name: Install dependencies
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzz
-          Rscript -e "devtools::install(); BiocManager::install(c('bugsigdbr', 'readr'))"
+          BiocManager::install(c("bugsigdbr", "readr", "BiocFileCache", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports"))
+        shell: Rscript {0}
 
       - name: Setup git config
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
       - name: Export bugphyzz
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           rm *.gmt
-          Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
+          Rscript bugphyzzExports/inst/scripts/export_bugphyzz.R
         timeout-minutes: 20
 
       - name: Commit Exports
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
+          cd bugphyzzExports
           git add . 
           git commit -m "Weekly export update"
           git push origin main

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -10,42 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     container: bioconductor/bioconductor_docker:devel
     env:
-      GITHUB_PAT: ${{ secrets.wl_pat }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
-      - name: Checkout bugphyzzExports 
+      - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          path: bugphyzzExports
-
-      - name: Checkout bugphyzz
-        uses: actions/checkout@v3
-        with:
-          repository: waldronlab/bugphyzz
-          path: bugphyzz
 
       - name: Install dependencies
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzz
-          Rscript -e "devtools::install(); BiocManager::install(c('bugsigdbr', 'readr'))"
-
-      - name: Setup git config
-        run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
+          pkgs <- c("bugsigdbr", "logr", "BiocFileCache", "tidy", "BiocParallel", "sdgamboa/taxPPro", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports")
+          BiocManager::install(pkgs, dependencies = TRUE)
+        shell: Rscript {0}
 
       - name: Export bugphyzz
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           rm *.gmt
-          Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
+          Rscript inst/scripts/export_bugphyzz.R
         timeout-minutes: 20
 
       - name: Commit Exports
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
           git add . 
           git commit -m "Weekly export update"
           git push origin main

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -24,18 +24,20 @@ jobs:
 
       - name: Setup git config
         run: |
+          pwd
+          ls -Rla
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
       - name: Export bugphyzz
         run: |
           rm *.gmt
-          Rscript bugphyzzExports/inst/scripts/export_bugphyzz.R
+          Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
         timeout-minutes: 20
 
       - name: Commit Exports
         run: |
-          cd bugphyzzExports
+          cd $GITHUB_WORKSPACE/bugphyzzExports
           git add . 
           git commit -m "Weekly export update"
           git push origin main

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -10,35 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     container: bioconductor/bioconductor_docker:devel
     env:
-      GITHUB_PAT: ${{ secrets.wl_pat }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
-      - name: Checkout bugphyzzExports 
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          path: bugphyzzExports
-
-      - name: Checkout bugphyzz
-        uses: actions/checkout@v3
-        with:
-          repository: waldronlab/bugphyzz
-          path: bugphyzz
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzz
-          Rscript -e "devtools::install(); BiocManager::install(c('bugsigdbr', 'readr'))"
+          BiocManager::install(c("bugsigdbr", "readr", "BiocFileCache", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports"))
+        shell: Rscript {0}
 
       - name: Setup git config
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
       - name: Export bugphyzz
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           rm *.gmt
           Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
         timeout-minutes: 20

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -24,8 +26,6 @@ jobs:
 
       - name: Setup git config
         run: |
-          pwd
-          ls -Rla
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 

--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Export bugphyzz
         run: |
           rm *.gmt
-          Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
+          Rscript inst/scripts/export_bugphyzz.R
         timeout-minutes: 20
 
       - name: Commit Exports


### PR DESCRIPTION
We install BiocFileCache directly, along with other dependencies and simplify the workflow. There may still be an issue with the commit and PR being made; however, there also appears to be a bigger problem with error 137, which may be an out of memory event seen in my repo: https://github.com/jwokaty/bugphyzzExports/actions/runs/5930496039/job/16080334133#step:5:149

Close #19 .
