### PR TITLE
Fix dependencies, simplify

### DIFF
--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -10,42 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     container: bioconductor/bioconductor_docker:devel
     env:
-      GITHUB_PAT: ${{ secrets.wl_pat }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
-      - name: Checkout bugphyzzExports 
+      - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          path: bugphyzzExports
-
-      - name: Checkout bugphyzz
-        uses: actions/checkout@v3
-        with:
-          repository: waldronlab/bugphyzz
-          path: bugphyzz
 
       - name: Install dependencies
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzz
-          Rscript -e "devtools::install(); BiocManager::install(c('bugsigdbr', 'readr'))"
-
-      - name: Setup git config
-        run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
+          pkgs <- c("bugsigdbr", "logr", "BiocFileCache", "tidy", "BiocParallel", "sdgamboa/taxPPro", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports")
+          BiocManager::install(pkgs, dependencies = TRUE)
+        shell: Rscript {0}
 
       - name: Export bugphyzz
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
           rm *.gmt
-          Rscript $GITHUB_WORKSPACE/bugphyzzExports/inst/scripts/export_bugphyzz.R
+          Rscript inst/scripts/export_bugphyzz.R
         timeout-minutes: 20
 
       - name: Commit Exports
         run: |
-          cd $GITHUB_WORKSPACE/bugphyzzExports
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
           git add . 
           git commit -m "Weekly export update"
           git push origin main


### PR DESCRIPTION
We install BiocFileCache directly, along with other dependencies and simplify the workflow. There may still be an issue with the commit and PR being made; however, there also appears to be a bigger problem with error 137, which may be an out of memory event seen in my repo https://github.com/jwokaty/bugphyzzExports/actions/runs/5930496039/job/16080334133#step:5:149 and https://www.airplane.dev/blog/exit-code-137.

Close https://github.com/waldronlab/bugphyzzExports/pull/19 .