### PR TITLE
No bplapply

### DIFF
--- a/.github/workflows/export-bugphyzz.yml
+++ b/.github/workflows/export-bugphyzz.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pkgs <- c("bugsigdbr", "logr", "BiocFileCache", "tidy", "BiocParallel", "sdgamboa/taxPPro", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports")
+          pkgs <- c("waldronlab/bugsigdbr", "logr", "BiocFileCache", "tidy", "BiocParallel", "sdgamboa/taxPPro", "waldronlab/bugphyzz", "waldronlab/bugphyzzExports")
           BiocManager::install(pkgs, dependencies = TRUE)
         shell: Rscript {0}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bugphyzzExports
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))
@@ -15,7 +15,7 @@ Remotes:
     waldronlab/bugphyzz,
     ropensci/taxize@1.0-rc
 Suggests: 
-    bugphyzz,
+    bugphyzz (>=0.0.1.4),
     data.tree,
     purrr,
     rlang,


### PR DESCRIPTION
Numerous changes to export script for memory efficiency:
- no bplapply (seems to run much faster using simple loops anyways, and will use less memory)
- don't create multiple large objects in memory 
- don't rbind all physiologies into one big data.frame, keep as a list of data.frames
- remove unnecessary duplication of steps